### PR TITLE
Reducir consultas al API de Facturacom

### DIFF
--- a/modules/addons/facturacom/lib/Admin/CoreModule.php
+++ b/modules/addons/facturacom/lib/Admin/CoreModule.php
@@ -145,6 +145,8 @@ class CoreModule
         $facturaInvoiceList = [];
         $invoicesObj = Capsule::table('tblinvoices')
             ->where('tblinvoices.userid', $UserID)
+            ->where('tblinvoices.status', 'Paid')
+            ->where('tblinvoices.total', '>', '0.00')
             ->get();
         $NumInvoices = [];
 


### PR DESCRIPTION
Agregar 2 cláusulas que limitan la búsqueda de invoices en WHMCS a invoices pagados y cuyo total sea mayor a 0.00 , ya que es inecesario regresar invoices que no han sido pagados (o gratuitos), ya que no se deben permitir facturar.